### PR TITLE
Fix prob cache bug

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -983,10 +983,8 @@ std::pair<float,float> sigmoid(float alpha, float beta, float bonus) {
 
 bool Network::probe_cache(const GameState* const state,
                           Network::Netresult& result) {
-    bool cache_success = false;
-    if (m_nncache.lookup(state->board.get_hash(), result)) {
-        cache_success = true;
-    }
+    auto cache_success = m_nncache.lookup(state->board.get_hash(), result);
+
     // If we are not generating a self-play game, try to find
     // symmetries if we are in the early opening.
     if (!cache_success && !cfg_noise && !cfg_random_cnt
@@ -1005,6 +1003,7 @@ bool Network::probe_cache(const GameState* const state,
                 }
                 result.policy = std::move(corrected_policy);
                 cache_success = true;
+                break;
             }
         }
     }


### PR DESCRIPTION
The value may be mistake from cache because the NNCache Entry did not record the komi. If we set the different komi with cache and got the value from prob cache at the same time, it would get the wrong value.  