### PR TITLE
Fix the shared mutex stall (Need more tests).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ message(STATUS "Using built-in matrix library.")
 endif()
 find_package(Qt5Core)
 
-set(CMAKE_CXX_STANDARD 14)
+if(USE_CPP_17)
+  set(CMAKE_CXX_STANDARD 17)
+  add_definitions(-DUSE_STAND_SHARED_MUTEX)
+else()
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # See if we can set optimization flags as expected.

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -32,11 +32,17 @@
 
 #include "config.h"
 
+#ifdef USE_STAND_SHARED_MUTEX
+#include <shared_mutex>
+#else
+#include "SharedMutex.h"
+#endif
+
 #include <array>
 #include <deque>
 #include <memory>
-#include <mutex>
 #include <unordered_map>
+
 
 class NNCache {
 public:
@@ -101,9 +107,11 @@ public:
     // Return the estimated memory consumption of the cache.
     size_t get_estimated_size();
 private:
-
-    std::mutex m_mutex;
-
+#ifdef USE_STAND_SHARED_MUTEX
+    std::shared_mutex m_mutex;
+#else
+    SharedMutex m_mutex;
+#endif
     size_t m_size;
 
     // Statistics

--- a/src/SharedMutex.h
+++ b/src/SharedMutex.h
@@ -1,0 +1,108 @@
+#ifndef SHARED_MUTEX_H_INCLUDE
+#define SHARED_MUTEX_H_INCLUDE
+
+#include <atomic>
+#include <thread>
+#include <chrono>
+#include <cassert>
+
+class SharedMutex {
+public:
+    SharedMutex() {};
+
+    void lock();
+    void unlock();
+
+    void lock_shared();
+    void unlock_shared();
+
+private:
+    bool acquire_exclusive_lock();
+    int get_share_counter();
+
+    void take_break();
+
+    std::atomic<int> m_share_counter{0};
+    std::atomic<bool> m_exclusive{false};
+    std::chrono::microseconds m_wait_microseconds{0};
+};
+
+inline void SharedMutex::take_break() {
+    std::this_thread::sleep_for(m_wait_microseconds);
+}
+
+inline bool SharedMutex::acquire_exclusive_lock() {
+    bool expected = false;
+    return m_exclusive.compare_exchange_weak(expected, true);
+}
+
+inline int SharedMutex::get_share_counter() {
+    return m_share_counter.load();
+}
+
+inline void SharedMutex::lock() {
+    while (!acquire_exclusive_lock()) {
+        take_break();
+    }
+    while (get_share_counter() > 0) {
+        take_break();
+    }
+}
+
+inline void SharedMutex::unlock() {
+    m_exclusive.store(false);
+}
+
+inline void SharedMutex::lock_shared() {
+    while (true) {
+        m_share_counter.fetch_add(1);
+        if (m_exclusive.load()) {
+            m_share_counter.fetch_sub(1);
+	    } else {
+		    break;
+        }
+        while (m_exclusive.load()) {
+            take_break();
+        }
+    }
+}
+
+inline void SharedMutex::unlock_shared() {
+    m_share_counter.fetch_sub(1);
+}
+
+enum class lock_t {
+    X_LOCK,
+    S_LOCK
+};
+
+template<lock_t T>
+class LockGuard {
+public:
+    LockGuard(SharedMutex &sm);
+    ~LockGuard();
+
+private:
+    SharedMutex &m_sm;
+};
+
+template<>
+inline LockGuard<lock_t::X_LOCK>::LockGuard(SharedMutex& sm) : m_sm(sm) {
+    m_sm.lock();
+}
+
+template<>
+inline LockGuard<lock_t::X_LOCK>::~LockGuard() {
+    m_sm.unlock();
+}
+
+template<>
+inline LockGuard<lock_t::S_LOCK>::LockGuard(SharedMutex& sm) : m_sm(sm) {
+    m_sm.lock_shared();
+}
+
+template<>
+inline LockGuard<lock_t::S_LOCK>::~LockGuard() {
+    m_sm.unlock_shared();
+}
+#endif


### PR DESCRIPTION
The original shared mutex has stall issue.  I optimize the shared mutex. Now it is fast than before, even if the std::mutex version. I also add a option for c++17 shared mutex. If we want to use it, adding  " -DUSE_CPP_17=1" on cmake.

In order to benchmark against different mutex versions, I create a simple test. The test is that all different versions start from the same board( has been moved ). Then, do one "go" to collect playouts speed. All version sample ten times.

This is my my simple test result
std::mutex avg                     : 4212.2(playouts/second(s))
my shared mutex avg          : 4330.3(playouts/second(s))
c++17 shared mutex avg     : 4302.6(playouts/second(s))
Parameters:  ./sai  -w  <weights>  -p  100000  --noponder   --lambda 0.3  --mu 0.03  -t 10  -b 5
OS: Ubuntu
CPU: i5-9400f
GPU: RTX2070s
CUDA:10.2
OpenCL:1.2

This test tries to make all NNCache lookup fail. So, this test don't represent the real game. Need more tests. 

